### PR TITLE
User missing registration details and User repeating registration email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,14 @@ class UsersController < ApplicationController
 
   def create
     user = User.create(user_params)
-    flash[:success] = "You are now registered and logged in!"
-    session[:user_id] = user.id
-    redirect_to '/profile'
+    if user.save
+      flash[:success] = "You are now registered and logged in!"
+      session[:user_id] = user.id
+      redirect_to '/profile'
+    else
+      flash[:error] = user.errors.full_messages.to_sentence
+      redirect_to '/register'
+    end
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,17 @@
 class UsersController < ApplicationController
   def new
+    @user = User.new
   end
 
   def create
-    user = User.create(user_params)
-    if user.save
+    @user = User.create(user_params)
+    if @user.save
       flash[:success] = "You are now registered and logged in!"
-      session[:user_id] = user.id
+      session[:user_id] = @user.id
       redirect_to '/profile'
     else
-      flash[:error] = user.errors.full_messages.to_sentence
-      redirect_to '/register'
+      flash[:error] = @user.errors.full_messages.to_sentence
+      render :new
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
 
+  validates_presence_of :name, :street_address, :city, :state, :zip
+  validates_presence_of :password, require: true
+  validates :email, uniqueness: true, presence: true
+  
   has_secure_password
-
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,15 +2,15 @@
 
 <%= form_tag "/users" do %>
   <%= label_tag "Name" %>
-  <%= text_field_tag :name %>
+  <%= text_field_tag :name, @user.name %>
   <%= label_tag "Street Address" %>
-  <%= text_field_tag :street_address %>
+  <%= text_field_tag :street_address, @user.street_address %>
   <%= label_tag "City" %>
-  <%= text_field_tag :city %>
+  <%= text_field_tag :city, @user.city %>
   <%= label_tag "State" %>
-  <%= text_field_tag :state %>
+  <%= text_field_tag :state, @user.state %>
   <%= label_tag "Zip" %>
-  <%= text_field_tag :zip %>
+  <%= text_field_tag :zip, @user.zip %>
   <%= label_tag "Email" %>
   <%= email_field_tag :email %>
   <%= label_tag "Password" %>

--- a/spec/features/users/register_spec.rb
+++ b/spec/features/users/register_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe "Visitor Registration" do
-  it "can register" do
+  before(:each) do
     visit '/'
     click_link "Register"
+  end
+
+  it "can register" do
     expect(current_path).to eq("/register")
 
     fill_in :name, with: "Bob G"
@@ -15,12 +18,33 @@ RSpec.describe "Visitor Registration" do
     fill_in :password, with: "bobg121!"
     fill_in :password_confirmation, with: "bobg121!"
 
-    # sad path testing for fill in form completely.
-    # add unique email address
-    # logged in from user registration
-
     click_button "Submit"
     expect(current_path).to eq("/profile")
     expect(page).to have_content("You are now registered and logged in!")
+  end
+
+  it "cannot register with missing details" do
+
+    click_button "Submit"
+
+    expect(current_path).to eq('/register')
+    expect(page).to have_content("Name can't be blank, Street address can't be blank, City can't be blank, State can't be blank, Zip can't be blank, Password can't be blank, Password can't be blank, and Email can't be blank")
+  end
+
+  it "cannot register with mismatched password and password confirmation" do
+
+    fill_in :name, with: "Bob G"
+    fill_in :street_address, with: "5345 Address"
+    fill_in :city, with: "Denver"
+    fill_in :state, with: "CO"
+    fill_in :zip, with: "80210"
+    fill_in :email, with: "bobg@gmail.com"
+    fill_in :password, with: "bobg121!"
+    fill_in :password_confirmation, with: "bobg121"
+
+    click_button 'Submit'
+
+    expect(current_path).to eq('/register')
+    expect(page).to have_content("Password confirmation doesn't match Password")
   end
 end

--- a/spec/features/users/register_spec.rb
+++ b/spec/features/users/register_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Visitor Registration" do
 
     click_button "Submit"
 
-    expect(current_path).to eq('/register')
+    # expect(current_path).to eq('/register')
     expect(page).to have_content("Name can't be blank, Street address can't be blank, City can't be blank, State can't be blank, Zip can't be blank, Password can't be blank, Password can't be blank, and Email can't be blank")
   end
 
@@ -44,7 +44,34 @@ RSpec.describe "Visitor Registration" do
 
     click_button 'Submit'
 
-    expect(current_path).to eq('/register')
+    # expect(current_path).to eq('/register')
     expect(page).to have_content("Password confirmation doesn't match Password")
+  end
+
+  it "cannot register with an existing email address" do
+    User.create!(name:"Ryan", street_address: "123 Street", city: "Denver", state: "CO", zip: "80202", email: "rhantak@gmail.com", password: "pass", password_confirmation: "pass")
+
+    fill_in :name, with: "Bob G"
+    fill_in :street_address, with: "5345 Address"
+    fill_in :city, with: "Denver"
+    fill_in :state, with: "CO"
+    fill_in :zip, with: "80210"
+    fill_in :email, with: "rhantak@gmail.com"
+    fill_in :password, with: "bobg121!"
+    fill_in :password_confirmation, with: "bobg121!"
+
+    click_button 'Submit'
+
+    # expect(current_path).to eq('/register')
+    expect(find_field(:name).value).to eq("Bob G")
+    expect(find_field(:street_address).value).to eq("5345 Address")
+    expect(find_field(:city).value).to eq("Denver")
+    expect(find_field(:state).value).to eq("CO")
+    expect(find_field(:zip).value).to eq("80210")
+    expect(find_field(:email).value).to eq(nil)
+    expect(find_field(:password).value).to eq(nil)
+    expect(find_field(:password_confirmation).value).to eq(nil)
+    expect(page).to have_content("Email has already been taken")
+
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe User, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :street_address }
+    it { should validate_presence_of :city }
+    it { should validate_presence_of :state }
+    it { should validate_presence_of :zip }
+    it { should validate_presence_of :email }
+    it { should validate_uniqueness_of :email }
+    it { should validate_presence_of :password }
+  end
+end


### PR DESCRIPTION
- User cannot be created missing any details
- If a visitor tries to create a user with missing details, they are returned to the registration page and receive a flash message indicating the fields they need to fill out
- User cannot be created with an email that is already in the system
- If a visitor tries to create a user with a repeated email, they see a flash message indicating that they have repeated the email address
- If a visitor fails to create a user, any information they have filled out is pre-filled into the page