### PR TITLE
Add test for error when user changes email to one that is already used

### DIFF
--- a/spec/features/users/edit_profile_spec.rb
+++ b/spec/features/users/edit_profile_spec.rb
@@ -160,7 +160,7 @@ describe 'as a registered user' do
     it "I can't change my email address to one belonging to another user" do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
-      visit '/profile/edit'
+      visit '/profile/edit/profile'
 
       fill_in :email, with: "admin@gmail.com"
 

--- a/spec/features/users/edit_profile_spec.rb
+++ b/spec/features/users/edit_profile_spec.rb
@@ -156,5 +156,17 @@ describe 'as a registered user' do
       expect(page).to have_content('33333')
       expect(page).to have_content('merchant@gmail.com')
     end
+
+    it "I can't change my email address to one belonging to another user" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      visit '/profile/edit'
+
+      fill_in :email, with: "admin@gmail.com"
+
+      click_button 'Update Information'
+
+      expect(page).to have_content('Email has already been taken')
+    end
   end
 end


### PR DESCRIPTION
- Functionality was already handled by our error handling in the users#edit controlled, added a test to confirm this