### PR TITLE
Add message that a merchants inventory is too low to fulfill an item

### DIFF
--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -4,10 +4,10 @@
 <p><%= @order.city %>, <%= @order.state %>, <%= @order.zip %></p>
 
 <section>
-  <% @order.item_orders.each do |item_order| %> 
+  <% @order.item_orders.each do |item_order| %>
     <section id="item_order-<%= item_order.id %>">
       <% if item_order.filter_item_order(current_user.merchant_id) %>
-        <%= link_to(("#{item_order.item.name}"), "/items/#{item_order.item.id}") %> 
+        <%= link_to(("#{item_order.item.name}"), "/items/#{item_order.item.id}") %>
         <%= image_tag(item_order.item.image) %>
         <p>Price: <%= number_to_currency(item_order.price) %></p>
         <p>Quantity: <%= item_order.quantity %></p>
@@ -15,6 +15,8 @@
           <%= button_to "Fulfill Item", item_order_path(item_order.id), method: :patch %>
         <% elsif item_order.fulfilled %>
           <p>"Fulfilled"</p>
+        <% else %>
+          <p>"Inventory is too low to fulfill"</p>
         <% end %>
       <% end %>
     </section>

--- a/spec/features/merchant/merchant_fulfills_item_order_spec.rb
+++ b/spec/features/merchant/merchant_fulfills_item_order_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'As a merchant employee or admin' do
         role: 2,
         merchant_id: @mike.id
       )
-        
+
       @user = User.create(
         name: "Dee",
         street_address: "4233 Street",
@@ -34,12 +34,12 @@ RSpec.describe 'As a merchant employee or admin' do
       @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
       @order_1 = @user.orders.create(name: "Reg", address: "123 Street", city: "Denver", state: "CO", zip: "80202", user_id: @user.id)
       @item_order_1 = ItemOrder.create(order_id: @order_1.id, item_id: @paper.id, price: 20, quantity: 2)
-      @item_order_2 = ItemOrder.create(order_id: @order_1.id, item_id: @pencil.id, price: 2, quantity: 2)
+      @item_order_2 = ItemOrder.create(order_id: @order_1.id, item_id: @pencil.id, price: 2, quantity: 101)
       @item_order_3 = ItemOrder.create(order_id: @order_1.id, item_id: @tire.id, price: 100, quantity: 1)
       visit '/merchant'
       click_link "#{@order_1.id}"
     end
-  
+
     context 'For each item of mine in the order' do
       context 'If the users desired quantity is equal to or less than my current inventory quantity for that item' do
         it "I see a button or link to fulfill that item" do
@@ -55,7 +55,14 @@ RSpec.describe 'As a merchant employee or admin' do
             expect(page).to_not have_button("Fulfill Item")
           end
         end
+
+        it "if my inventory is too low to fulfill the item, I see text indicating my inventory is too low" do
+          within "#item_order-#{@item_order_2.id}" do
+            expect(page).to_not have_button('Fulfill Item')
+            expect(page).to have_content('Inventory is too low to fulfill')
+          end
+        end
       end
     end
-  end 
+  end
 end


### PR DESCRIPTION
- When a merchant views an order show page and there is an item on order for more than they have in stock, they now see an indication that their inventory is too low to fulfill an item